### PR TITLE
feat: Build Android APK on every commit to main

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -7,8 +7,6 @@ on:
 jobs:
   build_android:
     runs-on: ubuntu-latest
-    # Only run if commit message contain [build.apk]
-    if: contains(github.event.head_commit.message, '[build.apk]') || contains(github.event.head_commit.message, '[build]') || contains(github.event.head_commit.message, '[build.all]')
     outputs:
       apk_link: ${{steps.gdriveUpload_arm64.outputs.web-content-link}}
 


### PR DESCRIPTION
This change modifies the GitHub Actions workflow to build an Android APK on every commit to the `main` branch.

The `build_android` job in `.github/workflows/dart.yml` is updated to remove the conditional trigger based on the commit message. The build will now run for every commit pushed to the `main` branch.

<!--
# Pull Request
**Description:**  
Submit changes or improvements to Dartotsu

**Title:**  
Provide a concise and descriptive title for your pull request

**Description:**  
Clearly describe the purpose and scope of your pull request

**Summary of Changes:**  
Outline the key changes introduced in this pull request

**Type of Changes:**  
- Bug Fix
- Feature
- Enhancement
- Documentation

**Testing Notes:**  
Provide details on how this change has been tested

**Linked Issue(s):**  
Mention any related issues using their GitHub issue numbers

**Additional Context:**  
Include any other relevant information or context for your pull request

**Submission Checklist:**
- [ ] I have read and followed the project's contributing guidelines
- [ ] My code follows the code style of this project
- [ ] I have tested the changes and ensured they do not break existing functionality
- [ ] I have added or updated documentation as needed
- [ ] I have linked related issues in the description above
- [ ] I have tagged the appropriate reviewers for this pull request
-->
